### PR TITLE
feat: 更新AI模型配置 - 新增 Qwen3 Max Preview 和更新 Kimi 版本

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ python simulate_drone.py
 | **Meta** | Llama 4 Maverick, Llama 3.3 Turbo, etc | Cloud | Latest Llama models via providers |
 | **xAI** | Grok 4, Grok 3, Grok 3 mini, etc | Cloud | Elon Musk's xAI models |
 | **ZhipuAI** | GLM-4.5, GLM-4.5-Air, etc | Cloud | Chinese AI models with JWT auth |
-| **Tongyi Lab** | Qwen 3 235B, Qwen 3 Coder, etc | Cloud | Alibaba's latest Qwen 3 models |
+| **Tongyi Lab** | Qwen 3 Max Preview, Qwen 3 235B, Qwen 3 Coder, etc | Cloud | Alibaba's latest Qwen 3 models |
 | **DeepSeek** | DeepSeek Chat, DeepSeek Reasoner, etc | Cloud | Advanced reasoning models |
-| **Moonshot** | Kimi K2 Turbo, Kimi K2 Preview, etc | Cloud | Moonshot AI models |
+| **Moonshot** | Kimi K2 Turbo, Kimi K2 0905 Preview, etc | Cloud | Moonshot AI models |
 | **Ollama** | Qwen3:4B, GPT-OSS, Qwen3:30B, etc | Local/Network | Local & remote server support |
 
 ## 🔧 Requirements

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -117,9 +117,9 @@ python simulate_drone.py
 | **Meta** | Llama 4 Maverick, Llama 3.3 Turbo 等 | 云端 | 通过提供商的最新 Llama 模型 |
 | **xAI** | Grok 4, Grok 3, Grok 3 mini 等 | 云端 | 马斯克的 xAI 模型 |
 | **智谱AI** | GLM-4.5, GLM-4.5-Air 等 | 云端 | 中文 AI 模型，JWT 认证 |
-| **通义千问** | Qwen 3 235B, Qwen 3 Coder 等 | 云端 | 阿里巴巴最新 Qwen 3 模型 |
+| **通义千问** | Qwen 3 Max Preview, Qwen 3 235B, Qwen 3 Coder 等 | 云端 | 阿里巴巴最新 Qwen 3 模型 |
 | **DeepSeek** | DeepSeek Chat, DeepSeek Reasoner 等 | 云端 | 高级推理模型 |
-| **月之暗面** | Kimi K2 Turbo, Kimi K2 Preview 等 | 云端 | 月之暗面 AI 模型 |
+| **月之暗面** | Kimi K2 Turbo, Kimi K2 0905 Preview 等 | 云端 | 月之暗面 AI 模型 |
 | **Ollama** | Qwen3:4B, GPT-OSS, Qwen3:30B 等 | 本地/网络 | 本地和远程服务器支持 |
 
 ## 🔧 系统要求

--- a/drone/config.py
+++ b/drone/config.py
@@ -205,6 +205,14 @@ class ConfigManager:
                 temperature=0.7
             ),
             # Qwen via LiteLLM (OpenAI-compatible)
+            "qwen3-max-preview": ModelConfig(
+                name="qwen3-max-preview",
+                provider="qwen",
+                model_id="qwen3-max-preview",
+                base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+                max_tokens=2048,
+                temperature=0.7
+            ),
             "qwen3-235b-a22b-thinking-2507": ModelConfig(
                 name="qwen3-235b-a22b-thinking-2507",
                 provider="qwen",
@@ -247,10 +255,10 @@ class ConfigManager:
                 max_tokens=2048,
                 temperature=0.7
             ),
-            "kimi-k2-0711-preview": ModelConfig(
-                name="kimi-k2-0711-preview",
+            "kimi-k2-0905-preview": ModelConfig(
+                name="kimi-k2-0905-preview",
                 provider="moonshot",
-                model_id="kimi-k2-0711-preview",
+                model_id="kimi-k2-0905-preview",
                 base_url="https://api.moonshot.cn/v1",
                 max_tokens=2048,
                 temperature=0.7

--- a/drone/interactive_setup.py
+++ b/drone/interactive_setup.py
@@ -68,7 +68,7 @@ PROVIDERS = {
     },
     "Qwen": {
         "name": "qwen",
-        "models": ["qwen3-235b-a22b-thinking-2507", "qwen3-coder-480b-a35b-instruct"],
+        "models": ["qwen3-max-preview", "qwen3-235b-a22b-thinking-2507", "qwen3-coder-480b-a35b-instruct"],
         "api_key_url": "https://bailian.console.aliyun.com/ai/ak",
         "description": "Qwen3 models via DashScope (OpenAI-compatible)"
     },
@@ -80,7 +80,7 @@ PROVIDERS = {
     },
     "Kimi": {
         "name": "moonshot",
-        "models": ["kimi-k2-turbo-preview", "kimi-k2-0711-preview"],
+        "models": ["kimi-k2-turbo-preview", "kimi-k2-0905-preview"],
         "api_key_url": "https://platform.moonshot.cn/console/api-keys",
         "description": "Kimi models (OpenAI-compatible)"
     },

--- a/web_api.py
+++ b/web_api.py
@@ -228,7 +228,7 @@ async def get_providers():
         },
         "Qwen": {
             "name": "qwen",
-            "models": ["qwen3-235b-a22b-thinking-2507", "qwen3-coder-480b-a35b-instruct"],
+            "models": ["qwen3-max-preview", "qwen3-235b-a22b-thinking-2507", "qwen3-coder-480b-a35b-instruct"],
             "api_key_url": "https://bailian.console.aliyun.com/ai/ak",
             "description": "Qwen3 models via DashScope"
         },
@@ -240,7 +240,7 @@ async def get_providers():
         },
         "Kimi": {
             "name": "moonshot",
-            "models": ["kimi-k2-turbo-preview", "kimi-k2-0711-preview"],
+            "models": ["kimi-k2-turbo-preview", "kimi-k2-0905-preview"],
             "api_key_url": "https://platform.moonshot.cn/console/api-keys",
             "description": "Kimi models from Moonshot AI"
         },


### PR DESCRIPTION
 模型更新:
- Qwen 提供商: 新增 qwen3-max-preview 作为首选模型
- Kimi 提供商: 更新 kimi-k2-0711-preview  kimi-k2-0905-preview

 更新范围:
- drone/config.py: 默认模型配置字典
- web_api.py: Web界面API提供商列表
- drone/interactive_setup.py: CLI交互式设置选项
- README.md/README_ZH.md: 文档中的模型示例

 模型优先级:
- Qwen: qwen3-max-preview (新增首选)  qwen3-235b-a22b-thinking-2507  qwen3-coder-480b-a35b-instruct
- Kimi: kimi-k2-turbo-preview  kimi-k2-0905-preview (最新版本)

 用户体验:
- 所有界面(Web/CLI/交互式)模型选项完全同步
- 新用户默认看到最新推荐模型
- 保持向后兼容性