### PR TITLE
feat(qwen): expand available model presets

### DIFF
--- a/drone/config.py
+++ b/drone/config.py
@@ -221,10 +221,34 @@ class ConfigManager:
                 max_tokens=2048,
                 temperature=0.7
             ),
+            "qwen3-235b-a22b-instruct-2507": ModelConfig(
+                name="qwen3-235b-a22b-instruct-2507",
+                provider="qwen",
+                model_id="qwen3-235b-a22b-instruct-2507",
+                base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+                max_tokens=2048,
+                temperature=0.7
+            ),
             "qwen3-coder-plus": ModelConfig(
                 name="qwen3-coder-plus",
                 provider="qwen",
                 model_id="qwen3-coder-plus",
+                base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+                max_tokens=2048,
+                temperature=0.7
+            ),
+            "qwen3-next-80b-a3b-thinking": ModelConfig(
+                name="qwen3-next-80b-a3b-thinking",
+                provider="qwen",
+                model_id="qwen3-next-80b-a3b-thinking",
+                base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+                max_tokens=2048,
+                temperature=0.7
+            ),
+            "qwen3-next-80b-a3b-instruct": ModelConfig(
+                name="qwen3-next-80b-a3b-instruct",
+                provider="qwen",
+                model_id="qwen3-next-80b-a3b-instruct",
                 base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
                 max_tokens=2048,
                 temperature=0.7

--- a/drone/interactive_setup.py
+++ b/drone/interactive_setup.py
@@ -68,7 +68,7 @@ PROVIDERS = {
     },
     "Qwen": {
         "name": "qwen",
-        "models": ["qwen3-max", "qwen3-235b-a22b-thinking-2507", "qwen3-coder-plus"],
+        "models": ["qwen3-max", "qwen3-235b-a22b-thinking-2507", "qwen3-235b-a22b-instruct-2507", "qwen3-coder-plus", "qwen3-next-80b-a3b-thinking", "qwen3-next-80b-a3b-instruct"],
         "api_key_url": "https://bailian.console.aliyun.com/ai/ak",
         "description": "Qwen3 models via DashScope (OpenAI-compatible)"
     },

--- a/web_api.py
+++ b/web_api.py
@@ -228,7 +228,7 @@ async def get_providers():
         },
         "Qwen": {
             "name": "qwen",
-            "models": ["qwen3-max", "qwen3-235b-a22b-thinking-2507", "qwen3-coder-plus"],
+            "models": ["qwen3-max", "qwen3-235b-a22b-thinking-2507", "qwen3-235b-a22b-instruct-2507", "qwen3-coder-plus", "qwen3-next-80b-a3b-thinking", "qwen3-next-80b-a3b-instruct"],
             "api_key_url": "https://bailian.console.aliyun.com/ai/ak",
             "description": "Qwen3 models via DashScope"
         },


### PR DESCRIPTION
This pull request adds support for three new Qwen3 models to the system, making them available for configuration and selection in both the interactive setup and API provider listing. These updates ensure users can access the latest Qwen3 models via DashScope.

**Qwen3 model support:**

* Added configuration for the `qwen3-235b-a22b-instruct-2507`, `qwen3-next-80b-a3b-thinking`, and `qwen3-next-80b-a3b-instruct` models in the `_create_default_models` method of `drone/config.py`. [[1]](diffhunk://#diff-9362c0ea1dcbdcf6ed2080d22aa2312816e8466c2dbb2a0913ccad0b777ebfcfR224-R231) [[2]](diffhunk://#diff-9362c0ea1dcbdcf6ed2080d22aa2312816e8466c2dbb2a0913ccad0b777ebfcfR240-R255)
* Updated the Qwen provider's available models list in `drone/interactive_setup.py` to include the new models.
* Updated the Qwen provider's available models list in the API response in `web_api.py` to include the new models.