### PR TITLE
chore: reorder Qwen and Meta providers

### DIFF
--- a/drone/interactive_setup.py
+++ b/drone/interactive_setup.py
@@ -48,11 +48,11 @@ PROVIDERS = {
         "api_key_url": "https://aistudio.google.com/app/apikey",
         "description": "Gemini models from Google AI Studio"
     },
-    "Meta": {
-        "name": "openai",  # Using OpenAI format for Llama models via providers
-        "models": ["meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8", "llama/Llama-3.3-70B-Instruct-Turbo"],
-        "api_key_url": "https://together.ai/ or https://replicate.com/",
-        "description": "Llama models from Meta (via Together.ai/Replicate)"
+    "Qwen": {
+        "name": "qwen",
+        "models": ["qwen3-max", "qwen3-235b-a22b-thinking-2507", "qwen3-235b-a22b-instruct-2507", "qwen3-coder-plus", "qwen3-next-80b-a3b-thinking", "qwen3-next-80b-a3b-instruct"],
+        "api_key_url": "https://bailian.console.aliyun.com/ai/ak",
+        "description": "Qwen3 models via DashScope (OpenAI-compatible)"
     },
     "xAI": {
         "name": "xai",
@@ -66,12 +66,6 @@ PROVIDERS = {
         "api_key_url": "https://open.bigmodel.cn/usercenter/apikeys",
         "description": "GLM models from ZhipuAI"
     },
-    "Qwen": {
-        "name": "qwen",
-        "models": ["qwen3-max", "qwen3-235b-a22b-thinking-2507", "qwen3-235b-a22b-instruct-2507", "qwen3-coder-plus", "qwen3-next-80b-a3b-thinking", "qwen3-next-80b-a3b-instruct"],
-        "api_key_url": "https://bailian.console.aliyun.com/ai/ak",
-        "description": "Qwen3 models via DashScope (OpenAI-compatible)"
-    },
     "DeepSeek": {
         "name": "deepseek",
         "models": ["deepseek-chat", "deepseek-reasoner"],
@@ -83,6 +77,12 @@ PROVIDERS = {
         "models": ["kimi-k2-turbo-preview", "kimi-k2-0905-preview"],
         "api_key_url": "https://platform.moonshot.cn/console/api-keys",
         "description": "Kimi models (OpenAI-compatible)"
+    },
+    "Meta": {
+        "name": "openai",  # Using OpenAI format for Llama models via providers
+        "models": ["meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8", "llama/Llama-3.3-70B-Instruct-Turbo"],
+        "api_key_url": "https://together.ai/ or https://replicate.com/",
+        "description": "Llama models from Meta (via Together.ai/Replicate)"
     },
     "Ollama": {
         "name": "ollama",

--- a/web_api.py
+++ b/web_api.py
@@ -207,12 +207,11 @@ async def get_providers():
             "api_key_url": "https://aistudio.google.com/app/apikey",
             "description": "Gemini 2.5 models from Google AI Studio"
         },
-        "Meta": {
-            "name": "meta",
-            "models": ["meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8", "llama/Llama-3.3-70B-Instruct-Turbo"],
-            "api_key_url": "https://together.ai/",
-            "api_key_alternatives": ["https://replicate.com/", "https://openrouter.ai/"],
-            "description": "Latest Llama models via providers"
+        "Qwen": {
+            "name": "qwen",
+            "models": ["qwen3-max", "qwen3-235b-a22b-thinking-2507", "qwen3-235b-a22b-instruct-2507", "qwen3-coder-plus", "qwen3-next-80b-a3b-thinking", "qwen3-next-80b-a3b-instruct"],
+            "api_key_url": "https://bailian.console.aliyun.com/ai/ak",
+            "description": "Qwen3 models via DashScope"
         },
         "xAI": {
             "name": "xai",
@@ -226,12 +225,6 @@ async def get_providers():
             "api_key_url": "https://open.bigmodel.cn/usercenter/apikeys",
             "description": "GLM models from ZhipuAI"
         },
-        "Qwen": {
-            "name": "qwen",
-            "models": ["qwen3-max", "qwen3-235b-a22b-thinking-2507", "qwen3-235b-a22b-instruct-2507", "qwen3-coder-plus", "qwen3-next-80b-a3b-thinking", "qwen3-next-80b-a3b-instruct"],
-            "api_key_url": "https://bailian.console.aliyun.com/ai/ak",
-            "description": "Qwen3 models via DashScope"
-        },
         "DeepSeek": {
             "name": "deepseek",
             "models": ["deepseek-chat", "deepseek-reasoner"],
@@ -243,6 +236,13 @@ async def get_providers():
             "models": ["kimi-k2-turbo-preview", "kimi-k2-0905-preview"],
             "api_key_url": "https://platform.moonshot.cn/console/api-keys",
             "description": "Kimi models from Moonshot AI"
+        },
+        "Meta": {
+            "name": "meta",
+            "models": ["meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8", "llama/Llama-3.3-70B-Instruct-Turbo"],
+            "api_key_url": "https://together.ai/",
+            "api_key_alternatives": ["https://replicate.com/", "https://openrouter.ai/"],
+            "description": "Latest Llama models via providers"
         },
         "Ollama": {
             "name": "ollama",


### PR DESCRIPTION
This pull request updates the configuration for model providers in both `drone/interactive_setup.py` and `web_api.py`. The main change is a reordering of the "Meta" (Llama) and "Qwen" (Qwen3) providers: their definitions have been swapped in both files to ensure a consistent provider list order across the codebase. There are no functional changes to the provider details themselves.

Provider ordering updates:

* Moved the `Meta` (Llama) provider definition to appear after `Moonshot` and before `Ollama`, and the `Qwen` provider to appear after `Google` and before `xAI` in both `drone/interactive_setup.py` and `web_api.py`. [[1]](diffhunk://#diff-4122f422205b300e165201b90585ad96a70756bf0718e970ed176bb0cc1764c7L51-R55) [[2]](diffhunk://#diff-4122f422205b300e165201b90585ad96a70756bf0718e970ed176bb0cc1764c7L69-L74) [[3]](diffhunk://#diff-4122f422205b300e165201b90585ad96a70756bf0718e970ed176bb0cc1764c7R81-R86) [[4]](diffhunk://#diff-34f5eea0bfee838eaf876cbd60791507247c7488792fa7fefba714ff715c9652L210-R214) [[5]](diffhunk://#diff-34f5eea0bfee838eaf876cbd60791507247c7488792fa7fefba714ff715c9652L229-L234) [[6]](diffhunk://#diff-34f5eea0bfee838eaf876cbd60791507247c7488792fa7fefba714ff715c9652R240-R246)