### PR TITLE
docs: sync README provider updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![DeepDrone Demo](media/demo.png)
 
-**Control drones with natural language using the latest AI models from 10 major providers: OpenAI GPT-5, Anthropic Claude 4, Google Gemini 2.5, Meta Llama 4, xAI Grok 4, ZhipuAI GLM-4.5, Tongyi Lab Qwen 3, DeepSeek, Moonshot Kimi K2, and local/network Ollama models.**
+**Control drones with natural language using the latest AI models from 10 major providers: OpenAI GPT-5, Anthropic Claude 4, Google Gemini 2.5, Alibaba Qwen3 Max, xAI Grok 4, ZhipuAI GLM-4.5, DeepSeek, Moonshot Kimi K2, Meta Llama 4, and local/network Ollama models.**
 
 ---
 
@@ -81,13 +81,13 @@ python simulate_drone.py
 |----------|--------|----------|-------------|
 | **OpenAI** | GPT-5, GPT-5-mini, GPT-5-nano, etc | Cloud | Latest GPT-5 series models |
 | **Anthropic** | Claude 4 Opus, Claude 4 Sonnet, etc | Cloud | Advanced Claude 4 models |
-| **Google** | Gemini 2.5 Pro, Gemini 2.5 Flash, etc | Cloud | Google AI Studio integration |
-| **Meta** | Llama 4 Maverick, Llama 3.3 Turbo, etc | Cloud | Latest Llama models via providers |
+| **Google** | Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.5 Flash Lite | Cloud | Google AI Studio integration |
+| **Qwen** | Qwen3 Max, Qwen3 235B Instruct 2507, Qwen3 Coder Plus, Qwen3 Next 80B | Cloud | DashScope OpenAI-compatible endpoints |
 | **xAI** | Grok 4, Grok 4 Fast Reasoning, Grok 4 Fast Non-Reasoning, etc | Cloud | Elon Musk's xAI models |
 | **ZhipuAI** | GLM-4.5, GLM-4.5-Air, etc | Cloud | Chinese AI models with JWT auth |
-| **Tongyi Lab** | Qwen 3 Max Preview, Qwen 3 235B, Qwen 3 Coder, etc | Cloud | Alibaba's latest Qwen 3 models |
 | **DeepSeek** | DeepSeek Chat, DeepSeek Reasoner, etc | Cloud | Advanced reasoning models |
-| **Moonshot** | Kimi K2 Turbo, Kimi K2 0905 Preview, etc | Cloud | Moonshot AI models |
+| **Moonshot (Kimi)** | Kimi K2 Turbo, Kimi K2 0905 Preview, etc | Cloud | Moonshot AI models |
+| **Meta** | Llama 4 Maverick, Llama 3.3 Turbo, etc | Cloud | Latest Llama models via providers |
 | **Ollama** | Qwen3:4B, GPT-OSS, Qwen3:30B, etc | Local/Network | Local & remote server support |
 
 ## 🔧 Requirements
@@ -100,7 +100,7 @@ python simulate_drone.py
 ## 💻 Tech Stack
 
 - **LiteLLM** - Unified interface for cloud AI models (OpenAI, Anthropic, Google, xAI, etc.)
-- **Direct API Integration** - Native support for ZhipuAI, Tongyi Lab Qwen, DeepSeek, Moonshot Kimi
+- **Direct API Integration** - Native support for ZhipuAI, Qwen (DashScope), DeepSeek, Moonshot Kimi
 - **Ollama** - Local/Network AI model execution with custom server support
 - **DroneKit-Python** - Real drone control and telemetry
 - **Rich** - Beautiful terminal interface and formatting

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -2,7 +2,7 @@
 
 ![DeepDrone Demo](media/demo.png)
 
-**使用自然语言控制无人机，支持来自 10 大主流提供商的最新 AI 模型：OpenAI GPT-5、Anthropic Claude 4、Google Gemini 2.5、Meta Llama 4、xAI Grok 4、智谱AI GLM-4.5、通义千问 Qwen 3、DeepSeek、月之暗面 Kimi K2，以及本地/网络 Ollama 模型。**
+**使用自然语言控制无人机，支持来自 10 大主流提供商的最新 AI 模型：OpenAI GPT-5、Anthropic Claude 4、Google Gemini 2.5、阿里巴巴 Qwen3 Max、xAI Grok 4、智谱AI GLM-4.5、DeepSeek、月之暗面 Kimi K2、Meta Llama 4，以及本地/网络 Ollama 模型。**
 
 ---
 
@@ -113,13 +113,13 @@ python simulate_drone.py
 |--------|------|----------|------|
 | **OpenAI** | GPT-5, GPT-5-mini, GPT-5-nano 等 | 云端 | 最新 GPT-5 系列模型 |
 | **Anthropic** | Claude 4 Opus, Claude 4 Sonnet 等 | 云端 | 先进的 Claude 4 模型 |
-| **Google** | Gemini 2.5 Pro, Gemini 2.5 Flash 等 | 云端 | Google AI Studio 集成 |
-| **Meta** | Llama 4 Maverick, Llama 3.3 Turbo 等 | 云端 | 通过提供商的最新 Llama 模型 |
+| **Google** | Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.5 Flash Lite | 云端 | Google AI Studio 集成 |
+| **Qwen** | Qwen3 Max, Qwen3 235B Instruct 2507, Qwen3 Coder Plus, Qwen3 Next 80B | 云端 | DashScope 提供的 OpenAI 兼容接口 |
 | **xAI** | Grok 4, Grok 4 Fast Reasoning, Grok 4 Fast Non-Reasoning 等 | 云端 | 马斯克的 xAI 模型 |
 | **智谱AI** | GLM-4.5, GLM-4.5-Air 等 | 云端 | 中文 AI 模型，JWT 认证 |
-| **通义千问** | Qwen 3 Max Preview, Qwen 3 235B, Qwen 3 Coder 等 | 云端 | 阿里巴巴最新 Qwen 3 模型 |
 | **DeepSeek** | DeepSeek Chat, DeepSeek Reasoner 等 | 云端 | 高级推理模型 |
-| **月之暗面** | Kimi K2 Turbo, Kimi K2 0905 Preview 等 | 云端 | 月之暗面 AI 模型 |
+| **月之暗面（Kimi）** | Kimi K2 Turbo, Kimi K2 0905 Preview 等 | 云端 | 月之暗面 AI 模型 |
+| **Meta** | Llama 4 Maverick, Llama 3.3 Turbo 等 | 云端 | 通过提供商的最新 Llama 模型 |
 | **Ollama** | Qwen3:4B, GPT-OSS, Qwen3:30B 等 | 本地/网络 | 本地和远程服务器支持 |
 
 ## 🔧 系统要求
@@ -132,7 +132,7 @@ python simulate_drone.py
 ## 💻 技术栈
 
 - **LiteLLM** - 云端 AI 模型统一接口（OpenAI、Anthropic、Google、xAI 等）
-- **直接 API 集成** - 原生支持智谱AI、通义千问 Qwen、DeepSeek、月之暗面 Kimi
+- **直接 API 集成** - 原生支持智谱AI、Qwen（DashScope）、DeepSeek、月之暗面 Kimi
 - **Ollama** - 本地/网络 AI 模型执行，支持自定义服务器
 - **DroneKit-Python** - 真实无人机控制和遥测
 - **Rich** - 美观的终端界面和格式化


### PR DESCRIPTION
This pull request updates the documentation to reflect new supported AI model providers and clarifies model integration details for both English and Chinese audiences. The main changes are the replacement of "Tongyi Lab Qwen" with "Alibaba Qwen3 Max" and the addition of specific Qwen models and DashScope integration, as well as minor adjustments to provider and model listings.

**Provider and model listing updates:**

* Updated all provider lists to replace "Tongyi Lab Qwen" with "Alibaba Qwen3 Max" and moved Meta Llama 4 to the end of the list in both `README.md` and `README_ZH.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-e8764f49c916f94863b7aad80d30a29f7761a297d0b24be2c244cf90ce23d85aL5-R5)
* Expanded the table of supported models to include detailed Qwen3 variants and clarified that Qwen integration uses DashScope OpenAI-compatible endpoints. Also, reorganized the Moonshot and Meta provider entries for clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R90) [[2]](diffhunk://#diff-e8764f49c916f94863b7aad80d30a29f7761a297d0b24be2c244cf90ce23d85aL116-R122)

**Integration and tech stack clarifications:**

* Updated the tech stack section to specify that direct API integration is now for ZhipuAI, Qwen (DashScope), DeepSeek, and Moonshot Kimi, removing Tongyi Lab Qwen. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R103) [[2]](diffhunk://#diff-e8764f49c916f94863b7aad80d30a29f7761a297d0b24be2c244cf90ce23d85aL135-R135)