### PR TITLE
feat: add LongCat Flash models support and update provider information

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![DeepDrone Demo](media/demo.png)
 
-**Control drones with natural language using the latest AI models from 10 major providers: OpenAI GPT-5, Anthropic Claude 4, Google Gemini 2.5, Alibaba Qwen3 Max, xAI Grok 4, ZhipuAI GLM-4.5, DeepSeek, Moonshot Kimi K2, Meta Llama 4, and local/network Ollama models.**
+**Control drones with natural language using the latest AI models from 11 major providers: OpenAI GPT-5, Anthropic Claude 4, Google Gemini 2.5, Alibaba Qwen3 Max, xAI Grok 4, ZhipuAI GLM-4.5, DeepSeek, Moonshot Kimi K2, LongCat Flash, Meta Llama 4, and local/network Ollama models.**
 
 ---
 
@@ -40,14 +40,14 @@ python start_web.py
 ```
 
 The app will guide you through:
-- **AI Provider Selection**: Choose from 10 providers with latest models
+- **AI Provider Selection**: Choose from 11 providers with latest models
 - **Model Selection**: Pick from cutting-edge AI models (network Ollama supported)
 - **Drone Connection**: Connect to simulator or real drone
 - **Natural Language Control**: "Take off to 30 meters", "Fly in a square pattern"
 
 ## ✨ Features
 
-- 🤖 **Comprehensive AI Support**: 10 major providers with latest models (GPT-5, Claude 4, Gemini 2.5, Llama 4, Grok 4, etc.)
+- 🤖 **Comprehensive AI Support**: 11 major providers with latest models (GPT-5, Claude 4, Gemini 2.5, Moonshot Kimi K2, LongCat Flash, Llama 4, Grok 4, etc.)
 - 🌐 **Dual Interface**: Terminal CLI and modern web interface
 - 🌐 **Network Flexibility**: Local, LAN, and internet Ollama server support
 - 🚁 **Real Drone Control**: DroneKit integration for actual flight control
@@ -87,6 +87,7 @@ python simulate_drone.py
 | **ZhipuAI** | GLM-4.5, GLM-4.5-Air, etc | Cloud | Chinese AI models with JWT auth |
 | **DeepSeek** | DeepSeek Chat, DeepSeek Reasoner, etc | Cloud | Advanced reasoning models |
 | **Moonshot (Kimi)** | Kimi K2 Turbo, Kimi K2 0905 Preview, etc | Cloud | Moonshot AI models |
+| **LongCat** | LongCat Flash Chat, LongCat Flash Thinking | Cloud | OpenAI-compatible LongCat Flash models |
 | **Meta** | Llama 4 Maverick, Llama 3.3 Turbo, etc | Cloud | Latest Llama models via providers |
 | **Ollama** | Qwen3:4B, GPT-OSS, Qwen3:30B, etc | Local/Network | Local & remote server support |
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -2,7 +2,7 @@
 
 ![DeepDrone Demo](media/demo.png)
 
-**使用自然语言控制无人机，支持来自 10 大主流提供商的最新 AI 模型：OpenAI GPT-5、Anthropic Claude 4、Google Gemini 2.5、阿里巴巴 Qwen3 Max、xAI Grok 4、智谱AI GLM-4.5、DeepSeek、月之暗面 Kimi K2、Meta Llama 4，以及本地/网络 Ollama 模型。**
+**使用自然语言控制无人机，支持来自 11 大主流提供商的最新 AI 模型：OpenAI GPT-5、Anthropic Claude 4、Google Gemini 2.5、阿里巴巴 Qwen3 Max、xAI Grok 4、智谱AI GLM-4.5、DeepSeek、月之暗面 Kimi K2、美团 LongCat Flash、Meta Llama 4，以及本地/网络 Ollama 模型。**
 
 ---
 
@@ -40,14 +40,14 @@ python start_web.py
 ```
 
 应用程序将引导您完成：
-- **AI 提供商选择**：从 10 个提供商中选择最新模型
+- **AI 提供商选择**：从 11 个提供商中选择最新模型
 - **模型选择**：选择前沿 AI 模型（支持网络 Ollama）
 - **无人机连接**：连接到模拟器或真实无人机
 - **自然语言控制**："起飞到30米"，"飞行正方形路线"
 
 ## ✨ 功能特性
 
-- 🤖 **全面的 AI 支持**：10 大主流提供商的最新模型（GPT-5、Claude 4、Gemini 2.5、Llama 4、Grok 4 等）
+- 🤖 **全面的 AI 支持**：11 大主流提供商的最新模型（GPT-5、Claude 4、Gemini 2.5、月之暗面 Kimi K2、美团 LongCat Flash、Llama 4、Grok 4 等）
 - 🌐 **双重界面**：终端 CLI 和现代化 Web 界面
 - 🌐 **网络灵活性**：支持本地、局域网和互联网 Ollama 服务器
 - 🚁 **真实无人机控制**：DroneKit 集成，支持实际飞行控制
@@ -119,6 +119,7 @@ python simulate_drone.py
 | **智谱AI** | GLM-4.5, GLM-4.5-Air 等 | 云端 | 中文 AI 模型，JWT 认证 |
 | **DeepSeek** | DeepSeek Chat, DeepSeek Reasoner 等 | 云端 | 高级推理模型 |
 | **月之暗面（Kimi）** | Kimi K2 Turbo, Kimi K2 0905 Preview 等 | 云端 | 月之暗面 AI 模型 |
+| **美团 LongCat** | LongCat Flash Chat, LongCat Flash Thinking | 云端 | OpenAI 兼容的 LongCat Flash 系列模型 |
 | **Meta** | Llama 4 Maverick, Llama 3.3 Turbo 等 | 云端 | 通过提供商的最新 Llama 模型 |
 | **Ollama** | Qwen3:4B, GPT-OSS, Qwen3:30B 等 | 本地/网络 | 本地和远程服务器支持 |
 

--- a/drone/config.py
+++ b/drone/config.py
@@ -145,6 +145,22 @@ class ConfigManager:
                 max_tokens=2048,
                 temperature=0.7
             ),
+            "longcat-flash-chat": ModelConfig(
+                name="longcat-flash-chat",
+                provider="longcat",
+                model_id="LongCat-Flash-Chat",
+                base_url="https://api.longcat.chat/openai/v1",
+                max_tokens=2048,
+                temperature=0.7
+            ),
+            "longcat-flash-thinking": ModelConfig(
+                name="longcat-flash-thinking",
+                provider="longcat",
+                model_id="LongCat-Flash-Thinking",
+                base_url="https://api.longcat.chat/openai/v1",
+                max_tokens=2048,
+                temperature=0.7
+            ),
             "llama-4-maverick-17b-128e-instruct-fp8": ModelConfig(
                 name="llama-4-maverick-17b-128e-instruct-fp8",
                 provider="openai",
@@ -368,7 +384,7 @@ class ConfigManager:
         """Get list of models that require API keys."""
         api_models = []
         for name, config in self.models.items():
-            if config.provider in ["openai", "anthropic", "zhipuai", "qwen", "deepseek", "moonshot"]:
+            if config.provider in ["openai", "anthropic", "zhipuai", "qwen", "deepseek", "moonshot", "longcat", "xai"]:
                 api_models.append(name)
         return api_models
 

--- a/drone/interactive_setup.py
+++ b/drone/interactive_setup.py
@@ -78,6 +78,12 @@ PROVIDERS = {
         "api_key_url": "https://platform.moonshot.cn/console/api-keys",
         "description": "Kimi models (OpenAI-compatible)"
     },
+    "LongCat": {
+        "name": "longcat",
+        "models": ["LongCat-Flash-Chat", "LongCat-Flash-Thinking"],
+        "api_key_url": "https://longcat.chat/platform/",
+        "description": "LongCat Flash models (OpenAI-compatible)"
+    },
     "Meta": {
         "name": "openai",  # Using OpenAI format for Llama models via providers
         "models": ["meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8", "llama/Llama-3.3-70B-Instruct-Turbo"],
@@ -469,6 +475,8 @@ def start_interactive_session():
         # Set base URLs for other providers
         if provider_name.lower() == "qwen":
             base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        elif provider_name.lower() == "longcat":
+            base_url = "https://api.longcat.chat/openai/v1"
         
         model_config = ModelConfig(
             name=f"{provider_name.lower()}-session",

--- a/drone/llm_interface.py
+++ b/drone/llm_interface.py
@@ -26,7 +26,7 @@ class LLMInterface:
             self._setup_ollama()
         elif self.model_config.provider == "zhipuai":
             self._setup_zhipuai()
-        elif self.model_config.provider in ["qwen", "deepseek", "moonshot", "xai"]:
+        elif self.model_config.provider in ["qwen", "deepseek", "moonshot", "xai", "longcat"]:
             # Use OpenAI-compatible HTTP for providers with OpenAI-style endpoints
             self._setup_openai_compatible()
         else:
@@ -146,6 +146,8 @@ class LLMInterface:
                     base_url = "https://api.moonshot.cn/v1"
                 elif self.model_config.provider == "xai":
                     base_url = "https://api.x.ai/v1"
+                elif self.model_config.provider == "longcat":
+                    base_url = "https://api.longcat.chat/openai/v1"
                 else:
                     raise ValueError("Base URL required for OpenAI-compatible provider")
 

--- a/web_api.py
+++ b/web_api.py
@@ -237,6 +237,12 @@ async def get_providers():
             "api_key_url": "https://platform.moonshot.cn/console/api-keys",
             "description": "Kimi models from Moonshot AI"
         },
+        "LongCat": {
+            "name": "longcat",
+            "models": ["LongCat-Flash-Chat", "LongCat-Flash-Thinking"],
+            "api_key_url": "https://longcat.chat/platform/",
+            "description": "LongCat Flash models with thinking support"
+        },
         "Meta": {
             "name": "meta",
             "models": ["meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8", "llama/Llama-3.3-70B-Instruct-Turbo"],


### PR DESCRIPTION
This pull request adds support for the LongCat Flash models as a new AI provider across the codebase and documentation. The changes ensure that users can select and use LongCat Flash models (OpenAI-compatible) for drone control, with updates to both English and Chinese documentation, configuration, provider selection, and API handling.

### LongCat Flash model support

* Added LongCat Flash models (`longcat-flash-chat`, `longcat-flash-thinking`) to the default model configuration in `drone/config.py`, specifying provider, model IDs, and API endpoint.
* Included LongCat as a selectable AI provider in both interactive setup (`drone/interactive_setup.py`) and web API (`web_api.py`), with model options and API key instructions. [[1]](diffhunk://#diff-4122f422205b300e165201b90585ad96a70756bf0718e970ed176bb0cc1764c7R81-R86) [[2]](diffhunk://#diff-34f5eea0bfee838eaf876cbd60791507247c7488792fa7fefba714ff715c9652R240-R245)

### Integration and compatibility

* Updated logic for identifying models requiring API keys to include LongCat as an API-based provider in `drone/config.py`.
* Modified client setup in `drone/llm_interface.py` to treat LongCat as an OpenAI-compatible provider, ensuring correct endpoint handling. [[1]](diffhunk://#diff-d86e68b77eb6a0fdfd31a96072242ee1e22636c10bdd81708b6fa2135f914504L29-R29) [[2]](diffhunk://#diff-d86e68b77eb6a0fdfd31a96072242ee1e22636c10bdd81708b6fa2135f914504R149-R150)
* Set the correct base URL for LongCat during interactive session setup in `drone/interactive_setup.py`.

### Documentation updates (English and Chinese)

* Updated `README.md` and `README_ZH.md` to reflect support for 11 providers, including LongCat Flash, and listed its models and features in provider tables and feature highlights. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R50) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R90) [[4]](diffhunk://#diff-e8764f49c916f94863b7aad80d30a29f7761a297d0b24be2c244cf90ce23d85aL5-R5) [[5]](diffhunk://#diff-e8764f49c916f94863b7aad80d30a29f7761a297d0b24be2c244cf90ce23d85aL43-R50) [[6]](diffhunk://#diff-e8764f49c916f94863b7aad80d30a29f7761a297d0b24be2c244cf90ce23d85aR122)