### PR TITLE
Add MiniMax M2.5 defaults and reorder provider list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![DeepDrone Demo](media/demo.png?v=2)
 
-**Control drones with natural language using the latest AI models from 11 major providers: OpenAI GPT-5.3 Codex, Anthropic Claude 4.6, Google Gemini 3.1 Pro Preview, Alibaba Qwen3.5 Plus/Flash, xAI Grok 4.1, ZhipuAI GLM-5, DeepSeek, Moonshot Kimi K2.5, LongCat Flash, Meta Llama 4, and local/network Ollama models.**
+**Control drones with natural language using the latest AI models from 12 major providers: OpenAI GPT-5.3 Codex, Anthropic Claude 4.6, Google Gemini 3.1 Pro Preview, Alibaba Qwen3.5 Plus/Flash, xAI Grok 4.1, ZhipuAI GLM-5, MiniMax, DeepSeek, Moonshot Kimi K2.5, LongCat Flash, Meta Llama 4, and local/network Ollama models.**
 
 ---
 
@@ -35,14 +35,14 @@ uv run start_web.py
 ```
 
 The app will guide you through:
-- **AI Provider Selection**: Choose from 11 providers with latest models
+- **AI Provider Selection**: Choose from 12 providers with latest models
 - **Model Selection**: Pick from cutting-edge AI models (network Ollama supported)
 - **Drone Connection**: Connect to simulator or real drone
 - **Natural Language Control**: "Take off to 30 meters", "Fly in a square pattern"
 
 ## ✨ Features
 
-- 🤖 **Comprehensive AI Support**: 11 major providers with latest models (GPT-5.3 Codex, Claude 4.6, Gemini 3.1 Pro Preview, Kimi K2.5, LongCat Flash, Llama 4, Grok 4.1, etc.)
+- 🤖 **Comprehensive AI Support**: 12 major providers with latest models (GPT-5.3 Codex, Claude 4.6, Gemini 3.1 Pro Preview, MiniMax, Kimi K2.5, LongCat Flash, Llama 4, Grok 4.1, etc.)
 - 🌐 **Dual Interface**: Terminal CLI and modern web interface
 - 🌐 **Network Flexibility**: Local, LAN, and internet Ollama server support
 - 🚁 **Real Drone Control**: DroneKit integration for actual flight control
@@ -80,6 +80,7 @@ uv run simulate_drone.py
 | **Qwen** | Qwen3.5 Plus, Qwen3.5 Flash, Qwen3.5 397B A17B, Qwen3.5 122B A10B, Qwen3.5 27B, Qwen3.5 35B A3B | Cloud | DashScope OpenAI-compatible endpoints |
 | **xAI** | Grok 4.1 Fast Reasoning, Grok 4.1 Fast Non-Reasoning, Grok 4 | Cloud | Elon Musk's xAI models |
 | **ZhipuAI** | GLM-5, GLM-4.7-Flash, etc | Cloud | Chinese AI models with JWT auth |
+| **MiniMax** | MiniMax-M2.5, MiniMax-M2.5-highspeed | Cloud | MiniMax-M2.5 models from MiniMax |
 | **DeepSeek** | DeepSeek Chat, DeepSeek Reasoner, etc | Cloud | Advanced reasoning models |
 | **Moonshot (Kimi)** | Kimi K2.5, Kimi K2 Thinking Turbo, Kimi K2 Turbo, Kimi K2 Thinking, Kimi K2 0905 Preview | Cloud | Moonshot AI Kimi K2 models with thinking support |
 | **LongCat** | LongCat Flash Thinking 2601, LongCat Flash Chat, LongCat Flash Thinking, LongCat Flash Lite | Cloud | OpenAI-compatible LongCat Flash models |
@@ -98,7 +99,7 @@ uv run simulate_drone.py
 
 - **uv** - Fast Python package manager and project tool
 - **LiteLLM** - Unified interface for cloud AI models (OpenAI, Anthropic, Google, xAI, etc.)
-- **Direct API Integration** - Native support for ZhipuAI, Qwen (DashScope), DeepSeek, Moonshot Kimi
+- **Direct API Integration** - Native support for ZhipuAI, Qwen (DashScope), MiniMax, DeepSeek, Moonshot Kimi
 - **Ollama** - Local/Network AI model execution with custom server support
 - **DroneKit-Python** - Real drone control and telemetry
 - **Rich** - Beautiful terminal interface and formatting

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -112,7 +112,7 @@ uv run simulate_drone.py
 | **Qwen** | Qwen3.5 Plus, Qwen3.5 Flash, Qwen3.5 397B A17B, Qwen3.5 122B A10B, Qwen3.5 27B, Qwen3.5 35B A3B | 云端 | DashScope 提供的 OpenAI 兼容接口 |
 | **xAI** | Grok 4.1 Fast Reasoning, Grok 4.1 Fast Non-Reasoning, Grok 4 | 云端 | 马斯克的 xAI 模型 |
 | **智谱AI** | GLM-5, GLM-4.7-Flash 等 | 云端 | 中文 AI 模型，JWT 认证 |
-| **MiniMax** | MiniMax-M2.5, MiniMax-M2.5-highspeed | 云端 | MiniMax-M2.5 models from MiniMax |
+| **MiniMax** | MiniMax-M2.5, MiniMax-M2.5-highspeed | 云端 | 来自 MiniMax 的 MiniMax-M2.5 模型 |
 | **DeepSeek** | DeepSeek Chat, DeepSeek Reasoner 等 | 云端 | 高级推理模型 |
 | **月之暗面（Kimi）** | Kimi K2.5, Kimi K2 Thinking Turbo, Kimi K2 Turbo, Kimi K2 Thinking, Kimi K2 0905 Preview 等 | 云端 | 月之暗面 AI Kimi K2 系列模型，支持思维链 |
 | **美团 LongCat** | LongCat Flash Thinking 2601, LongCat Flash Chat, LongCat Flash Thinking, LongCat Flash Lite | 云端 | OpenAI 兼容的 LongCat Flash 系列模型 |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -2,7 +2,7 @@
 
 ![DeepDrone Demo](media/demo.png?v=2)
 
-**使用自然语言控制无人机，支持来自 11 大主流提供商的最新 AI 模型：OpenAI GPT-5.3 Codex、Anthropic Claude 4.6、Google Gemini 3.1 Pro Preview、阿里巴巴 Qwen3.5 Plus/Flash、xAI Grok 4.1、智谱AI GLM-5、DeepSeek、月之暗面 Kimi K2.5、美团 LongCat Flash、Meta Llama 4，以及本地/网络 Ollama 模型。**
+**使用自然语言控制无人机，支持来自 12 大主流提供商的最新 AI 模型：OpenAI GPT-5.3 Codex、Anthropic Claude 4.6、Google Gemini 3.1 Pro Preview、阿里巴巴 Qwen3.5 Plus/Flash、xAI Grok 4.1、智谱AI GLM-5、MiniMax、DeepSeek、月之暗面 Kimi K2.5、美团 LongCat Flash、Meta Llama 4，以及本地/网络 Ollama 模型。**
 
 ---
 
@@ -35,14 +35,14 @@ uv run start_web.py
 ```
 
 应用程序将引导您完成：
-- **AI 提供商选择**：从 11 个提供商中选择最新模型
+- **AI 提供商选择**：从 12 个提供商中选择最新模型
 - **模型选择**：选择前沿 AI 模型（支持网络 Ollama）
 - **无人机连接**：连接到模拟器或真实无人机
 - **自然语言控制**："起飞到30米"，"飞行正方形路线"
 
 ## ✨ 功能特性
 
-- 🤖 **全面的 AI 支持**：11 大主流提供商的最新模型（GPT-5.3 Codex、Claude 4.6、Gemini 3.1 Pro Preview、Kimi K2.5、美团 LongCat Flash、Llama 4、Grok 4.1 等）
+- 🤖 **全面的 AI 支持**：12 大主流提供商的最新模型（GPT-5.3 Codex、Claude 4.6、Gemini 3.1 Pro Preview、MiniMax、Kimi K2.5、美团 LongCat Flash、Llama 4、Grok 4.1 等）
 - 🌐 **双重界面**：终端 CLI 和现代化 Web 界面
 - 🌐 **网络灵活性**：支持本地、局域网和互联网 Ollama 服务器
 - 🚁 **真实无人机控制**：DroneKit 集成，支持实际飞行控制
@@ -112,6 +112,7 @@ uv run simulate_drone.py
 | **Qwen** | Qwen3.5 Plus, Qwen3.5 Flash, Qwen3.5 397B A17B, Qwen3.5 122B A10B, Qwen3.5 27B, Qwen3.5 35B A3B | 云端 | DashScope 提供的 OpenAI 兼容接口 |
 | **xAI** | Grok 4.1 Fast Reasoning, Grok 4.1 Fast Non-Reasoning, Grok 4 | 云端 | 马斯克的 xAI 模型 |
 | **智谱AI** | GLM-5, GLM-4.7-Flash 等 | 云端 | 中文 AI 模型，JWT 认证 |
+| **MiniMax** | MiniMax-M2.5, MiniMax-M2.5-highspeed | 云端 | MiniMax-M2.5 models from MiniMax |
 | **DeepSeek** | DeepSeek Chat, DeepSeek Reasoner 等 | 云端 | 高级推理模型 |
 | **月之暗面（Kimi）** | Kimi K2.5, Kimi K2 Thinking Turbo, Kimi K2 Turbo, Kimi K2 Thinking, Kimi K2 0905 Preview 等 | 云端 | 月之暗面 AI Kimi K2 系列模型，支持思维链 |
 | **美团 LongCat** | LongCat Flash Thinking 2601, LongCat Flash Chat, LongCat Flash Thinking, LongCat Flash Lite | 云端 | OpenAI 兼容的 LongCat Flash 系列模型 |
@@ -130,7 +131,7 @@ uv run simulate_drone.py
 
 - **uv** - 快速 Python 包管理和项目工具
 - **LiteLLM** - 云端 AI 模型统一接口（OpenAI、Anthropic、Google、xAI 等）
-- **直接 API 集成** - 原生支持智谱AI、Qwen（DashScope）、DeepSeek、月之暗面 Kimi
+- **直接 API 集成** - 原生支持智谱AI、Qwen（DashScope）、MiniMax、DeepSeek、月之暗面 Kimi
 - **Ollama** - 本地/网络 AI 模型执行，支持自定义服务器
 - **DroneKit-Python** - 真实无人机控制和遥测
 - **Rich** - 美观的终端界面和格式化

--- a/drone/cli.py
+++ b/drone/cli.py
@@ -50,7 +50,7 @@ def chat(
         return
     
     # Check if model needs API key
-    if model_config.provider in ["openai", "anthropic", "zhipuai", "minimax"] and not model_config.api_key:
+    if model_config.provider != "ollama" and not model_config.api_key:
         console.print(f"[yellow]Model '{model}' requires an API key[/yellow]")
         if Confirm.ask("Would you like to set it now?"):
             set_api_key_interactive(model)

--- a/drone/cli.py
+++ b/drone/cli.py
@@ -50,7 +50,7 @@ def chat(
         return
     
     # Check if model needs API key
-    if model_config.provider in ["openai", "anthropic", "zhipuai"] and not model_config.api_key:
+    if model_config.provider in ["openai", "anthropic", "zhipuai", "minimax"] and not model_config.api_key:
         console.print(f"[yellow]Model '{model}' requires an API key[/yellow]")
         if Confirm.ask("Would you like to set it now?"):
             set_api_key_interactive(model)
@@ -136,7 +136,7 @@ def add_model(
     console.print(f"[green]Model '{name}' added successfully[/green]")
     
     # Ask for API key if needed
-    if provider in ["openai", "anthropic", "zhipuai"]:
+    if provider in ["openai", "anthropic", "zhipuai", "minimax"]:
         if Confirm.ask(f"Would you like to set the API key for '{name}' now?"):
             set_api_key_interactive(name)
 
@@ -275,6 +275,8 @@ def set_api_key_interactive(model_name: str, api_key: Optional[str] = None):
             console.print("Get your Kimi (Moonshot) API key from: https://platform.moonshot.cn/console/api-keys")
         elif model_config.provider == "xai":
             console.print("Get your xAI API key from: https://console.x.ai")
+        elif model_config.provider == "minimax":
+            console.print("Get your MiniMax API key from: https://platform.minimaxi.com/user-center/basic-information/interface-key")
         
         api_key = getpass.getpass("Enter API key (hidden): ")
     

--- a/drone/config.py
+++ b/drone/config.py
@@ -272,6 +272,23 @@ class ConfigManager:
                 max_tokens=2048,
                 temperature=0.7
             ),
+            # MiniMax via OpenAI-compatible API
+            "minimax-m2.5": ModelConfig(
+                name="minimax-m2.5",
+                provider="minimax",
+                model_id="MiniMax-M2.5",
+                base_url="https://api.minimaxi.com/v1",
+                max_tokens=2048,
+                temperature=0.7
+            ),
+            "minimax-m2.5-highspeed": ModelConfig(
+                name="minimax-m2.5-highspeed",
+                provider="minimax",
+                model_id="MiniMax-M2.5-highspeed",
+                base_url="https://api.minimaxi.com/v1",
+                max_tokens=2048,
+                temperature=0.7
+            ),
             # Qwen via 阿里云百炼平台API (OpenAI-compatible)
             "qwen3.5-plus": ModelConfig(
                 name="qwen3.5-plus",
@@ -452,7 +469,7 @@ class ConfigManager:
         """Get list of models that require API keys."""
         api_models = []
         for name, config in self.models.items():
-            if config.provider in ["openai", "anthropic", "zhipuai", "qwen", "deepseek", "moonshot", "longcat", "xai"]:
+            if config.provider in ["openai", "anthropic", "zhipuai", "qwen", "deepseek", "moonshot", "longcat", "xai", "minimax"]:
                 api_models.append(name)
         return api_models
 

--- a/drone/interactive_setup.py
+++ b/drone/interactive_setup.py
@@ -66,6 +66,12 @@ PROVIDERS = {
         "api_key_url": "https://open.bigmodel.cn/usercenter/apikeys",
         "description": "GLM models from ZhipuAI"
     },
+    "MiniMax": {
+        "name": "minimax",
+        "models": ["MiniMax-M2.5", "MiniMax-M2.5-highspeed"],
+        "api_key_url": "https://platform.minimaxi.com/user-center/basic-information/interface-key",
+        "description": "MiniMax-M2.5 models from MiniMax"
+    },
     "DeepSeek": {
         "name": "deepseek",
         "models": ["deepseek-chat", "deepseek-reasoner"],
@@ -382,6 +388,8 @@ def get_api_key(provider_name: str, model_name: str) -> Optional[str]:
         console.print("[dim]该 Key 将用于生成 JWT 以调用 ZhipuAI API。[/dim]\n")
     elif provider_name.lower() == "qwen":
         console.print("[yellow]提示：Qwen 使用 OpenAI 兼容通道，请填入 DashScope 的 API Key。[/yellow]\n")
+    elif provider_name.lower() == "minimax":
+        console.print("[yellow]提示：MiniMax 使用 OpenAI 兼容通道，请填入 MiniMax 的接口密钥。[/yellow]\n")
     
     try:
         # Use getpass for secure password input (works in all environments)
@@ -477,6 +485,8 @@ def start_interactive_session():
             base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
         elif provider_name.lower() == "longcat":
             base_url = "https://api.longcat.chat/openai/v1"
+        elif provider_name.lower() == "minimax":
+            base_url = "https://api.minimaxi.com/v1"
         
         model_config = ModelConfig(
             name=f"{provider_name.lower()}-session",

--- a/drone/llm_interface.py
+++ b/drone/llm_interface.py
@@ -26,7 +26,7 @@ class LLMInterface:
             self._setup_ollama()
         elif self.model_config.provider == "zhipuai":
             self._setup_zhipuai()
-        elif self.model_config.provider in ["qwen", "deepseek", "moonshot", "xai", "longcat"]:
+        elif self.model_config.provider in ["qwen", "deepseek", "moonshot", "xai", "longcat", "minimax"]:
             # Use OpenAI-compatible HTTP for providers with OpenAI-style endpoints
             self._setup_openai_compatible()
         else:
@@ -148,6 +148,8 @@ class LLMInterface:
                     base_url = "https://api.x.ai/v1"
                 elif self.model_config.provider == "longcat":
                     base_url = "https://api.longcat.chat/openai/v1"
+                elif self.model_config.provider == "minimax":
+                    base_url = "https://api.minimaxi.com/v1"
                 else:
                     raise ValueError("Base URL required for OpenAI-compatible provider")
 

--- a/frontend/src/pages/SettingsPage.js
+++ b/frontend/src/pages/SettingsPage.js
@@ -147,6 +147,7 @@ const SettingsPage = () => {
                : provider === 'deepseek' ? 'https://api.deepseek.com/v1'
                : provider === 'moonshot' ? 'https://api.moonshot.cn/v1'
                : provider === 'xai' ? 'https://api.x.ai/v1'
+               : provider === 'minimax' ? 'https://api.minimaxi.com/v1'
                : '',
     }));
 
@@ -493,7 +494,7 @@ const SettingsPage = () => {
               )}
 
               {/* Base URL (for Ollama and other providers) */}
-              {(modelConfig.provider === 'ollama' || modelConfig.provider === 'qwen' || modelConfig.provider === 'deepseek' || modelConfig.provider === 'moonshot' || modelConfig.provider === 'xai') && (
+              {(modelConfig.provider === 'ollama' || modelConfig.provider === 'qwen' || modelConfig.provider === 'deepseek' || modelConfig.provider === 'moonshot' || modelConfig.provider === 'xai' || modelConfig.provider === 'minimax') && (
                 <div className="form-group" style={{ gridColumn: 'span 2' }}>
                   <label className="form-label">
                     {modelConfig.provider === 'ollama' ? 'Ollama 服务器地址' : '基础 URL'}
@@ -515,6 +516,8 @@ const SettingsPage = () => {
                           ? 'https://api.moonshot.cn/v1'
                           : modelConfig.provider === 'xai'
                           ? 'https://api.x.ai/v1'
+                          : modelConfig.provider === 'minimax'
+                          ? 'https://api.minimaxi.com/v1'
                           : ''
                       }
                     />

--- a/uv.lock
+++ b/uv.lock
@@ -629,7 +629,7 @@ wheels = [
 
 [[package]]
 name = "deepdrone"
-version = "1.0.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },

--- a/web_api.py
+++ b/web_api.py
@@ -225,6 +225,12 @@ async def get_providers():
             "api_key_url": "https://open.bigmodel.cn/usercenter/apikeys",
             "description": "GLM models from ZhipuAI"
         },
+        "MiniMax": {
+            "name": "minimax",
+            "models": ["MiniMax-M2.5", "MiniMax-M2.5-highspeed"],
+            "api_key_url": "https://platform.minimaxi.com/user-center/basic-information/interface-key",
+            "description": "MiniMax-M2.5 models from MiniMax"
+        },
         "DeepSeek": {
             "name": "deepseek",
             "models": ["deepseek-chat", "deepseek-reasoner"],


### PR DESCRIPTION
## Summary
- add MiniMax provider support across backend, CLI, interactive setup, and web settings
- update MiniMax default models to MiniMax-M2.5 and MiniMax-M2.5-highspeed
- reorder provider display so MiniMax appears after ZhipuAI and before DeepSeek
- align MiniMax description text to style-consistent wording
- include uv.lock changes in this PR as requested

## Files touched
- README.md
- README_ZH.md
- drone/cli.py
- drone/config.py
- drone/interactive_setup.py
- drone/llm_interface.py
- frontend/src/pages/SettingsPage.js
- web_api.py
- uv.lock

## Validation
- PYTHONPYCACHEPREFIX=.pycache python3 -m py_compile drone/config.py drone/interactive_setup.py web_api.py
- npm run build --prefix frontend
